### PR TITLE
Addresses #8:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <!-- Build  ===================================================== -->
 
   <properties>
-    <osf-client.version>1.0.2</osf-client.version>
+    <osf-client.version>1.0.3-SNAPSHOT</osf-client.version>
     <osf-rdf.version>1.0.2</osf-rdf.version>
   </properties>
 
@@ -149,7 +149,7 @@
       <dependency>
         <groupId>org.dataconservancy.cos</groupId>
         <artifactId>osf-client</artifactId>
-        <version>1.0.2</version>
+        <version>${osf-client.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- Upgrade to version 1.0.3-SNAPSHOT of osf-client, which contains underlying fixes
- Obtain the OkHttpClient from the Spring context, which will be properly configured to access OSF endpoints that require authentication
- Improved the response of the CLI when attempting to access a URL that may require authorization